### PR TITLE
Iter5

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -58,7 +58,7 @@ func run(cfg *Config) {
 func loadConfig(cmd *cobra.Command) (*Config, error) {
 	cfg := &Config{}
 
-	err := env.Parse(&cfg)
+	err := env.Parse(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"github.com/GoLessons/go-musthave-metrics/internal/agent"
 	"github.com/GoLessons/go-musthave-metrics/internal/common/storage"
+	"github.com/caarlos0/env"
 	"github.com/spf13/cobra"
 	"os"
 	"time"
 )
 
 type Config struct {
-	Address        string
-	ReportInterval int
-	PollInterval   int
+	Address        string `env:"ADDRESS" envDefault:"localhost:8080"`
+	ReportInterval int    `env:"REPORT_INTERVAL" envDefault:"10"`
+	PollInterval   int    `env:"POLL_INTERVAL" envDefault:"2"`
 }
 
 func main() {
@@ -21,7 +22,12 @@ func main() {
 		Short: "Metrics agent for collecting and sending metrics",
 	}
 
-	cfg := loadConfig(rootCmd)
+	cfg, err := loadConfig(rootCmd)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
 
 		if cfg.ReportInterval <= 0 {
@@ -49,14 +55,19 @@ func run(cfg *Config) {
 	metricCollector.CollectAndSendMetrics()
 }
 
-func loadConfig(cmd *cobra.Command) *Config {
+func loadConfig(cmd *cobra.Command) (*Config, error) {
 	cfg := &Config{}
 
-	cmd.Flags().StringVarP(&cfg.Address, "address", "a", "localhost:8080", "HTTP server address")
-	cmd.Flags().IntVarP(&cfg.ReportInterval, "report", "r", 10, "Report interval in seconds")
-	cmd.Flags().IntVarP(&cfg.PollInterval, "poll", "p", 2, "Poll interval in seconds")
+	err := env.Parse(&cfg)
+	if err != nil {
+		return nil, err
+	}
 
-	return cfg
+	cmd.Flags().StringVarP(&cfg.Address, "address", "a", cfg.Address, "HTTP server address")
+	cmd.Flags().IntVarP(&cfg.ReportInterval, "report", "r", cfg.ReportInterval, "Report interval in seconds")
+	cmd.Flags().IntVarP(&cfg.PollInterval, "poll", "p", cfg.PollInterval, "Poll interval in seconds")
+
+	return cfg, nil
 }
 
 func MetricCollectorFactory(address string, reportInterval, pollInterval int) *agent.MetricCollector {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,7 +41,7 @@ func run(cfg *Config) error {
 func loadConfig(cmd *cobra.Command) (*Config, error) {
 	cfg := &Config{}
 
-	err := env.Parse(&cfg)
+	err := env.Parse(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,26 +6,34 @@ import (
 	"net/http"
 )
 
-var address string
-
-var rootCmd = &cobra.Command{
-	Use: "server",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return run()
-	},
-}
-
-func init() {
-	rootCmd.Flags().StringVarP(&address, "address", "a", "localhost:8080", "Metric server address")
-	rootCmd.FParseErrWhitelist.UnknownFlags = false
+type Config struct {
+	Address string
 }
 
 func main() {
+	var rootCmd = &cobra.Command{
+		Use: "server",
+	}
+
+	cfg := loadConfig(rootCmd)
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+
+		return run(cfg)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		panic(err)
 	}
 }
 
-func run() error {
-	return http.ListenAndServe(address, router.InitRouter())
+func run(cfg *Config) error {
+	return http.ListenAndServe(cfg.Address, router.InitRouter())
+}
+
+func loadConfig(cmd *cobra.Command) *Config {
+	cfg := &Config{}
+
+	cmd.Flags().StringVarP(&cfg.Address, "address", "a", "localhost:8080", "HTTP server address")
+
+	return cfg
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/caarlos0/env v3.5.0+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
+github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Доработайте **агент**, чтобы он мог изменять свои параметры запуска по умолчанию через переменные окружения:

- `ADDRESS` отвечает за адрес эндпоинта HTTP-сервера.
- `REPORT_INTERVAL` позволяет переопределять `reportInterval`.
- `POLL_INTERVAL` позволяет переопределять `pollInterval`.

Значения интервалов времени должны задаваться в секундах.

Доработайте **сервер**, чтобы он мог изменять свои параметры запуска по умолчанию через переменные окружения:
`ADDRESS` отвечает за адрес эндпоинта HTTP-сервера.

Приоритет параметров должен быть таким:

1. Если указана переменная окружения, то используется она.
2. Если нет переменной окружения, но есть аргумент командной строки (флаг), то используется он.
3. Если нет ни переменной окружения, ни флага, то используется значение по умолчанию.
